### PR TITLE
Update loa.yaml

### DIFF
--- a/loa.yaml
+++ b/loa.yaml
@@ -2951,7 +2951,7 @@ loa:
   - name: WOBURN (NO LANDING)
     add:
     - name: WOBURN (NO LANDING)
-      type: P
+      type: D_OTHER
       geometry:
       - upper: 1500 ft
         lower: SFC


### PR DESCRIPTION
Suggest changing WOBURN from "P" to "D_OTHER". I think it's misleading to state that the airspace is prohibited, when it's only the surface that is prohibited (by local request). Showing it as a danger zone with "NO LANDING" in the name makes it clear to pilots it may be dangerous to enter if they can't glide clear, without implying that it is legally prohibited airspace.