### PR TITLE
Fix Biggin Hill ATZ ceiling

### DIFF
--- a/airspace/airspace.yaml
+++ b/airspace/airspace.yaml
@@ -11924,7 +11924,7 @@ airspace:
   id: biggin-atz
   type: ATZ
   geometry:
-  - upper: 2000 ft
+  - upper: 2599 ft
     lower: SFC
     boundary:
     - circle:


### PR DESCRIPTION
Please double check me, but I believe the AIP shows ATZ ceiling as 2000 ft AGL, elevation 599 ft. Therefore ceiling should be 2599 ft AMSL