### PR TITLE
Rename CHURCH FENTON to LEEDS EAST

### DIFF
--- a/airspace.yaml
+++ b/airspace.yaml
@@ -12647,9 +12647,8 @@ airspace:
         centre: 535157N 0013938W
         to: 535955N 0014027W
 
-# Leeds East
-- name: CHURCH FENTON
-  id: fenton-atz
+- name: LEEDS EAST
+  id: leeds-east-atz
   type: ATZ
   geometry:
   - upper: 2029 ft

--- a/service.yaml
+++ b/service.yaml
@@ -366,7 +366,7 @@ service:
 
 - callsign: FENTON RADIO
   controls:
-  - fenton-atz
+  - leeds-east-atz
   frequency: 120.710
 
 - callsign: FLEETLANDS INFORMATION


### PR DESCRIPTION
Please ignore this if there is a specific reason for keeping the Church Fenton name, however it is a bit confusing having an ATZ name in OpenAir that is not listed in the AIP - particularly when checking activation times.