### PR TITLE
Aston Down LOA with Kemble

### DIFF
--- a/loa.yaml
+++ b/loa.yaml
@@ -2683,3 +2683,36 @@ loa:
           - 515851N 0003457W
           - 515842N 0003504W
           - 515820N 0003537W
+
+#----------------------------------------------------------------------
+- name: COTSWOLD COMPS
+  areas:
+  - name: KEMBLE ATZ
+    add:
+    - name: KEMBLE COMPETITION GLIDER SECTOR
+      type: G
+      geometry:
+      - upper: 2436 ft
+        lower: SFC
+        boundary:
+        - line:
+          - 514036N 0020631W
+        - arc:
+            dir: cw
+            radius: 2 nm
+            centre: 514005N 0020325W
+            to: 514144N 0020138W
+
+    replace:
+    - id: kemble-atz
+      geometry:
+      - upper: 2436 ft
+        lower: SFC
+        boundary:
+        - line:
+          - 514144N 0020138W
+        - arc:
+            dir: cw
+            radius: 2 nm
+            centre: 514005N 0020325W
+            to: 514036N 0020631W


### PR DESCRIPTION
Add Aston Down LOA with Kemble ATZ.

Based on the following OpenAir definitions:
```
*
AC CTR
AN KEMBLE ATZ 118.430
AF 118.430
AL SFC
AH 2436ALT
DP 51:41:44 N 002:01:38 W
V D=+
V X=51:40:05 N 002:03:25 W
DB 51:41:44 N 002:01:38 W, 51:40:36 N 002:06:31 W
*
AC G
AN KEMBLE COMPETITION GLIDER SECTOR
AL SFC
AH 2436ALT
DP 51:40:36 N 002:06:31 W
V D=+
V X=51:40:05 N 002:03:25 W
DB 51:40:36 N 002:06:31 W, 51:41:44 N 002:01:38 W
*
```