### PR TITLE
List Dunkeswell DZ as 'intense'

### DIFF
--- a/airspace.yaml
+++ b/airspace.yaml
@@ -9200,6 +9200,8 @@ airspace:
 - name: DUNKESWELL
   type: D_OTHER
   localtype: DZ
+  rules:
+  - INTENSE
   geometry:
   - id: dunkeswell-dz
     upper: FL150


### PR DESCRIPTION
Suggest upgrading Dunkeswell DZ to "intense" as this is a very busy parachute DZ that should generally be considered an area to avoid for competition task setting.