### PR TITLE
Additional DZs as 'intense'

### DIFF
--- a/airspace.yaml
+++ b/airspace.yaml
@@ -9309,6 +9309,8 @@ airspace:
 - name: NETHERAVON
   type: D_OTHER
   localtype: DZ
+  rules:
+  - INTENSE
   geometry:
   - upper: FL150
     lower: SFC
@@ -9320,6 +9322,8 @@ airspace:
 - name: OLD SARUM
   type: D_OTHER
   localtype: DZ
+  rules:
+  - INTENSE
   geometry:
   - upper: FL150
     lower: SFC


### PR DESCRIPTION
Old Sarum and Netheravon DZs updated to "intense" as these DZs should generally be considered areas to avoid for competition task setting.