### PR TITLE
Kemble Class D standard NOTAM airspace

### DIFF
--- a/rat.yaml
+++ b/rat.yaml
@@ -359,3 +359,80 @@ rat:
     - circle:
         radius: 2 nm
         centre: 511100N 0021558W
+
+- name: KEMBLE TEMPO CLASS D
+  type: D
+  geometry:
+  # CTR 5NM radius Kemble
+  - upper: 4000 ft
+    lower: SFC
+    boundary:
+    - circle:
+        radius: 5 nm
+        centre: 514005N 0020325W
+  # CTR 1 (over Kemble)
+  - lower: SFC
+    upper: 5000 ft
+    boundary:
+    - line:
+      - 514117N 0020916W
+      - 514028N 0020214W
+      - 513928N 0015338W
+      - 513840N 0014648W
+      - 513519N 0014558W
+      - 513208N 0021806W
+      - 513217N 0021925W
+      - 514016N 0022132W
+      - 514117N 0020916W
+  # CTR 2 (over Tetbury)
+  - lower: SFC
+    upper: 4000 ft
+    boundary:
+    - line:
+      - 514706N 0020509W
+      - 514314N 0015058W
+      - 514313N 0015050W
+      - 514120N 0015001W
+      - 514144N 0014743W
+      - 513840N 0014648W
+      - 513928N 0015338W
+      - 514028N 0020214W
+      - 514056N 0020619W
+      - 514706N 0020509W
+  # CTA 1 (over Fairford)
+  - lower: 4000 ft
+    upper: FL095
+    boundary:
+    - line:
+      - 514454N 0014947W
+      - 514412N 0014010W
+      - 513945N 0012646W
+      - 513911N 0012629W
+      - 513640N 0013011W
+      - 513928N 0015338W
+      - 514454N 0014947W
+  # CTA 2 (over Brize Norton)
+  - lower: 4000 ft
+    upper: FL105
+    boundary:
+    - line:
+      - 515242N 0015604W
+      - 514951N 0013158W
+      - 513945N 0012646W
+      - 514412N 0014010W
+      - 514454N 0014947W
+      - 513928N 0015338W
+      - 514028N 0020214W
+      - 514117N 0020916W
+      - 514707N 0020509W
+      - 515242N 0015604W
+  # CTA 3 (over Cheltenham)
+  - lower: FL75
+    upper: FL195
+    boundary:
+    - line:
+      - 520412N 0020545W
+      - 515242N 0015604W
+      - 514707N 0020509W
+      - 515703N 0021633W
+      - 520412N 0020545W

--- a/rat.yaml
+++ b/rat.yaml
@@ -360,9 +360,10 @@ rat:
         radius: 2 nm
         centre: 511100N 0021558W
 
-- name: KEMBLE TEMPO CLASS D
+- name: KEMBLE CLASS D (NOTAM)
   type: D
   geometry:
+  # It would be good to be able to name each of these sectors in the output file.
   # CTR 5NM radius Kemble
   - upper: 4000 ft
     lower: SFC


### PR DESCRIPTION
Adding the default Kemble Class D airspace so that it can be added to output files (or separate RAT only file if required). 

I still need to double-check all the sector dimensions to ensure they match the current template.

Note for @ahsparrow - it would be good to be able to label each sector (e.g. "CTR 1", "CTA 2")  if that's supported in the format.